### PR TITLE
fix: Update numeric generic to handle u32 and bignum dependency

### DIFF
--- a/noir-circuits/blob/Nargo.toml
+++ b/noir-circuits/blob/Nargo.toml
@@ -5,7 +5,4 @@ authors = [""]
 compiler_version = ">=0.30.0"
 
 [dependencies]
-# bigint = { path = "../../../nargo/github.com/hashcloak/noir-bigintmain/" }
-# bigint = { path = "../../../nargo/github.com/zac-williamson/noir-bignum/main" }
-# bigint = {tag = "main", git = "https://github.com/iAmMichaelConnor/noir-bignum" }
-bigint = {tag = "main", git = "https://github.com/zac-williamson/noir-bignum" }
+bigint = {tag = "v0.3.0", git = "https://github.com/noir-lang/noir-bignum" }

--- a/noir-circuits/blob/src/main.nr
+++ b/noir-circuits/blob/src/main.nr
@@ -12,20 +12,20 @@ mod smaller_config;
 //     negative_roots::NEGATIVE_ROOTS
 // };
 use crate::smaller_config::{
-    BigNum, Bls12_381_Fr_Params, F, FIELDS_PER_BLOB, LOG_FIELDS_PER_BLOB, NOIR_FIELDS_PER_BLOB,
+    BigNum, BLS12_381_Fr_Params, F, FIELDS_PER_BLOB, LOG_FIELDS_PER_BLOB, NOIR_FIELDS_PER_BLOB,
     FIELDS_CARRYING_AN_EXTRA_BIT_PER_BLOB, D, D_INV, ROOTS, NEGATIVE_ROOTS
 };
 
 use std::hash::poseidon2;
 
-unconstrained fn __batch_invert_impl<let N: u64>(mut x: [F; N]) -> [F; N] {
+unconstrained fn __batch_invert_impl<let N: u32>(mut x: [F; N]) -> [F; N] {
     let mut accumulator: F = BigNum::one();
 
     let mut temporaries: [F] = &[];
     for i in 0..x.len() {
         temporaries = temporaries.push_back(accumulator);
         if (x[i].__is_zero() == false) {
-            accumulator = accumulator.__mulmod(x[i]);
+            accumulator = accumulator.__mul(x[i]);
         }
     }
 
@@ -34,8 +34,8 @@ unconstrained fn __batch_invert_impl<let N: u64>(mut x: [F; N]) -> [F; N] {
     for i in 0..x.len() {
         let idx = x.len() - 1 - i;
         if (x[idx].__is_zero() == false) {
-            T0 = accumulator.__mulmod(temporaries[idx]);
-            accumulator = accumulator.__mulmod(x[idx]);
+            T0 = accumulator.__mul(temporaries[idx]);
+            accumulator = accumulator.__mul(x[idx]);
             x[idx] = T0;
         }
     }
@@ -46,7 +46,7 @@ unconstrained fn __batch_invert_impl<let N: u64>(mut x: [F; N]) -> [F; N] {
 // unconstrained fn __compute_inv_denoms(z: F) -> [F; FIELDS_PER_BLOB] {
 //     let mut denoms: [F; FIELDS_PER_BLOB] = [BigNum::new(); FIELDS_PER_BLOB];
 //     for i in 0..FIELDS_PER_BLOB {
-//         denoms[i] = z.__submod(ROOTS[i]);
+//         denoms[i] = z.__sub(ROOTS[i]);
 //     }
 //     __batch_invert_impl(denoms)
 // }
@@ -242,13 +242,13 @@ fn main(blob: [F; FIELDS_PER_BLOB], kzg_commitment: [Field; 2]) -> pub (Field, F
 fn barycentric_evaluate_blob_at_z(z: F, ys: [F; FIELDS_PER_BLOB]) -> F {
     // z ^ D:
 
-    let mut t1 = z.__mulmod(z);
+    let mut t1 = z.__mul(z);
 
     BigNum::evaluate_quadratic_expression([[z]], [[false]], [[z]], [[false]], [t1], [true]);
 
     let mut t2: F = BigNum::new();
     for _i in 0..LOG_FIELDS_PER_BLOB - 1 {
-        t2 = t1.__mulmod(t1);
+        t2 = t1.__mul(t1);
 
         // GRATUITOUS USAGE OF as_witness, LIKE THROWING DARTS AT A DARTBOARD AND HOPING THIS HELPS
         std::as_witness(t2.limbs[0]);
@@ -269,12 +269,12 @@ fn barycentric_evaluate_blob_at_z(z: F, ys: [F; FIELDS_PER_BLOB]) -> F {
 
     let one: F = BigNum::one();
 
-    t1 = z_pow_d.__submod(one);
+    t1 = z_pow_d.__sub(one);
     std::as_witness(t1.limbs[0]);
     std::as_witness(t1.limbs[1]);
     std::as_witness(t1.limbs[2]);
 
-    let factor = t1.__mulmod(D_INV);
+    let factor = t1.__mul(D_INV);
 
     // (z_pow_d - one) * (D_INV) - factor = 0
     // z_pow_d * D_INV - D_INV - factor = 0
@@ -307,7 +307,7 @@ fn barycentric_evaluate_blob_at_z(z: F, ys: [F; FIELDS_PER_BLOB]) -> F {
 
     let mut denoms = [BigNum::new(); FIELDS_PER_BLOB];
     for i in 0..FIELDS_PER_BLOB {
-        denoms[i] = z.__addmod(NEGATIVE_ROOTS[i]);
+        denoms[i] = z.__add(NEGATIVE_ROOTS[i]);
     }
     let inv_denoms = __batch_invert_impl(denoms);
 
@@ -316,7 +316,7 @@ fn barycentric_evaluate_blob_at_z(z: F, ys: [F; FIELDS_PER_BLOB]) -> F {
         let num = root_i;
         let inv_denom = inv_denoms[i];
 
-        let frac = num.__mulmod(inv_denom);
+        let frac = num.__mul(inv_denom);
 
         // roots[i] / (z + neg_roots[i]) = frac 
         // && (z + neg_roots[i]) * inv_denom = 1.
@@ -385,8 +385,8 @@ fn barycentric_evaluate_blob_at_z(z: F, ys: [F; FIELDS_PER_BLOB]) -> F {
             std::as_witness(rhs[j].limbs[1]);
             std::as_witness(rhs[j].limbs[2]);
 
-            let summand = ys[k].__mulmod(fracs[k]);
-            let partial_sum_out = partial_sum.__addmod(summand);
+            let summand = ys[k].__mul(fracs[k]);
+            let partial_sum_out = partial_sum.__add(summand);
 
             std::as_witness(partial_sum_out.limbs[0]);
             std::as_witness(partial_sum_out.limbs[1]);
@@ -408,7 +408,7 @@ fn barycentric_evaluate_blob_at_z(z: F, ys: [F; FIELDS_PER_BLOB]) -> F {
             std::as_witness(partial_sum.limbs[1]);
             std::as_witness(partial_sum.limbs[2]);
         }
-        let mut sum_out = sum.__addmod(partial_sum);
+        let mut sum_out = sum.__add(partial_sum);
 
         BigNum::evaluate_quadratic_expression(
             [[]],
@@ -448,7 +448,7 @@ fn barycentric_evaluate_blob_at_z(z: F, ys: [F; FIELDS_PER_BLOB]) -> F {
 
     // y:
 
-    let y = factor.__mulmod(sum);
+    let y = factor.__mul(sum);
 
     BigNum::evaluate_quadratic_expression([[factor]], [[false]], [[sum]], [[false]], [y], [true]);
 

--- a/noir-circuits/blob/src/smaller_config.nr
+++ b/noir-circuits/blob/src/smaller_config.nr
@@ -1,6 +1,6 @@
-use dep::bigint::{BigNum, fields::bls12381Fr::Bls12_381_Fr_Params};
+use dep::bigint::{BigNum, fields::bls12_381Fr::BLS12_381_Fr_Params};
 
-type F = BigNum<3, Bls12_381_Fr_Params>;
+type F = BigNum<3, BLS12_381_Fr_Params>;
 
 global FIELDS_PER_BLOB: u64 = 8; // actually 4096
 global LOG_FIELDS_PER_BLOB: u64 = 3; // actually 12


### PR DESCRIPTION
noir-bignum was outdated. We now use the tagged version on the noir-lang org ([v0.3.0](https://github.com/noir-lang/noir-bignum/tree/v0.3.0))

There was also an instance of numeric generics that used a `u64` type which was banned after 0.32.0. 

Running `nargo test --show-output test_barycentric` using Noir master:
On main takes 3s
On domain-size-4096 takes about 5 min
